### PR TITLE
fix: rename commands

### DIFF
--- a/binary-command.yaml
+++ b/binary-command.yaml
@@ -1,5 +1,5 @@
 namespace: screwdriver-cd-test
-name: binary-test
+name: binary-func-test
 description: |
    Test command for binary format
 maintainer: foo@example.com

--- a/habitat-command.yaml
+++ b/habitat-command.yaml
@@ -1,5 +1,5 @@
 namespace: screwdriver-cd-test
-name: habitat-test
+name: habitat-func-test
 description: |
    Test command for habitat format
 maintainer: foo@example.com

--- a/promote-command.yaml
+++ b/promote-command.yaml
@@ -1,5 +1,5 @@
 namespace: screwdriver-cd-test
-name: promote-test
+name: promote-func-test
 description: |
    Test command for promote
 maintainer: foo@example.com


### PR DESCRIPTION
The pipeline was broken yesterday. While debugging, I deleted the functional-commands pipeline. After recreating the pipeline, need to rename the steps since permission tie to the old pipelineId.

Related: https://github.com/screwdriver-cd/screwdriver/pull/1374