### PR TITLE
fix: [2] add piped sd-cmd execution.

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -5,7 +5,9 @@ jobs:
   binary:
     steps:
       - publish: sd-cmd publish -f binary-command.yaml
-      - exec: sd-cmd exec screwdriver-cd-test/binary-func-test@1 foo bar
+      # default pipe size: 64KB (65536)
+      # see http://man7.org/linux/man-pages/man7/pipe.7.html
+      - exec: dd if=/dev/zero bs=65537 count=1 | sd-cmd exec screwdriver-cd-test/binary-func-test@1 foo bar
 
   habitat:
     steps:

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ -p /dev/stdin ]; then
+  # abandon (piped) stdin for test
+  cat - > /dev/null
+fi
+
 echo "$@"
 
 exit 0


### PR DESCRIPTION
## Context

We add piped `sd-cmd` execution test for https://github.com/screwdriver-cd/sd-cmd/pull/35.

## Objective

- `screwdriver-cd-test/binary-func-test` sd-cmd can receive stdin.  
```
$ ./test.sh foo bar
foo bar
$ echo $?
0

# default pipe size: 64KB (65536)
$ dd if=/dev/zero bs=65537 count=1 | ./test.sh foo bar
1+0 records in
1+0 records out
65537 bytes (66 kB, 64 KiB) copied, 0.000705801 s, 92.9 MB/s
foo bar
$ echo $?
0
```
- piped `sd-cmd` execution

## References

- https://github.com/screwdriver-cd/sd-cmd/pull/35

## TODO

- [ ] This PR is blocked by https://github.com/screwdriver-cd/screwdriver/pull/1680

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
