### PR TITLE
fix: Add maintainer for sd-cmds

### DIFF
--- a/sd-distrusted-command.yaml
+++ b/sd-distrusted-command.yaml
@@ -2,6 +2,8 @@
 namespace: screwdriver-cd-test
 # Command name itself
 name: test-distrusted-command
+# Command maintainer
+maintainer: foo@example.com
 # Description of the command and what it does
 description: command for testing for distrusted
 # Major and Minor version number (patch is automatic)

--- a/sd-trusted-command.yaml
+++ b/sd-trusted-command.yaml
@@ -2,6 +2,8 @@
 namespace: screwdriver-cd-test
 # Command name itself
 name: test-trusted-command
+# Command maintainer
+maintainer: foo@example.com
 # Description of the command and what it does
 description: command for testing for trusted
 # Major and Minor version number (patch is automatic)


### PR DESCRIPTION
Seeing this error: 
```
17:54:31 $ sd-cmd publish -f sd-trusted-command.yaml
17:54:31 ERROR: Post failed: Screwdriver API 400 Bad Request: Command has invalid format: 1 error(s).
```